### PR TITLE
Adding function references so that the library can be used from Java …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,8 @@ test.dependsOn scalaTest
 
 tasks.rat {
      excludes.add("**/build/**")
+     excludes.add("**/.idea/**")
+     excludes.add("**/*.iml")
      excludes.add("**/LICENSE.md")
      excludes.add("**/CONTRIBUTING.md")
      excludes.add("**/CODE_OF_CONDUCT.md")

--- a/src/main/scala/com/paypal/risk/platform/veda/analytics/anomaly/statistical/Functions.scala
+++ b/src/main/scala/com/paypal/risk/platform/veda/analytics/anomaly/statistical/Functions.scala
@@ -50,6 +50,9 @@ object Functions {
   def statResultThreshold(threshold: Double)(value: StatisticalResult[_]): Boolean =
     value.result > threshold
 
+  def statResultThresholdFunction[T](threshold: Double): Function1[StatisticalResult[T], Boolean] =
+    Functions.statResultThreshold(threshold)
+
   object Categorical {
 
     /**
@@ -101,6 +104,11 @@ object Functions {
       }
     }
 
+    def avgRefFunction[T](): Function1[Seq[Map[T, Long]], Map[T, Long]] =
+      avgRef
+
+    def entropyFunction[T](): Function2[Map[T, Long], Map[T, Long], StatisticalResult[T]] =
+      entropy
   }
 
   object Numerical {
@@ -158,6 +166,16 @@ object Functions {
         case _ => 0.0
       }
     }
+
+    def meanFunction[T]()(implicit numType: Numeric[T]): Function1[Iterable[T], Double] =
+      mean
+
+    def stdevFunction[T]()(implicit numType: Numeric[T]): Function2[Iterable[T], Double, Double] =
+      stdev
+
+    def avgMeanAndStdevRefFunction[T](): Function1[Seq[StatisticsContainer[T]], Option[(Mean, Stddev)]] =
+      avgMeanAndStdevRef
+
   }
 
   object Clustering {
@@ -199,5 +217,21 @@ object Functions {
       Clust4jHDBSCAN.returnOutliers(candidatePoints.asJava, refPoints.map(_.asJava).asJava,
         minCorePoints, minClusterSizeForExtraction).asScala
     }
+
+    def DBSCANFunction(): Function2[Double, Int,
+      Function2[Seq[Array[Double]], Seq[Seq[Array[Double]]], Seq[Array[Double]]]] =
+      DBSCAN
+
+    def DBSCANFunction(eps: Double, minNeighbors: Int): Function2[Seq[Array[Double]],
+      Seq[Seq[Array[Double]]], Seq[Array[Double]]] =
+      DBSCAN(eps, minNeighbors)
+
+    def HDBSCANFunction(): Function2[Int, Int,
+      Function2[Seq[Array[Double]], Seq[Seq[Array[Double]]], Seq[Array[Double]]]] =
+      HDBSCAN
+
+    def HDBSCANFunction(minCorePoints: Int, minNeighbors: Int): Function2[Seq[Array[Double]],
+      Seq[Seq[Array[Double]]], Seq[Array[Double]]] =
+      HDBSCAN(minCorePoints, minNeighbors)
   }
 }

--- a/src/main/scala/com/paypal/risk/platform/veda/analytics/clustering/ClusteringAlgorithms.scala
+++ b/src/main/scala/com/paypal/risk/platform/veda/analytics/clustering/ClusteringAlgorithms.scala
@@ -63,4 +63,12 @@ object ClusteringAlgorithms {
     Clust4jHDBSCAN.cluster(latestWindowPoints.asJava, refPoints.map(_.asJava).asJava,
       minCorePoints, minClusterSizeForExtraction)
   }
+
+  def DBSCANFunction(eps: Double, minNeighbors: Int):
+    Function2[Seq[Array[Double]], Seq[Seq[Array[Double]]], Clustering] =
+    DBSCAN(eps, minNeighbors)
+
+  def HDBSCANFunction(minCorePoints: Int, minNeighbors: Int):
+    Function2[Seq[Array[Double]], Seq[Seq[Array[Double]]], Clustering] =
+    HDBSCAN(minCorePoints, minNeighbors)
 }


### PR DESCRIPTION
Adding explicit function references so that functions can be referred to from within Java code as well as Scala code. This is needed because the Scala syntactic sugar of referring to function is not available in Java, and so turning a scala function to a FunctionX object is impossible. (It is possible using the scala-java8-compat package, however the resultant functions are not serializable which doesn't work with spark)
